### PR TITLE
INF-428 Chrome integration test 브라우저 버전 일치

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -177,7 +177,15 @@ jobs:
             - run: |
                 echo Installed chromium version: ${{ steps.setup-chrome.outputs.chrome-version }}
                 ${{ steps.setup-chrome.outputs.chrome-path }} --version
+            - name: Configure Chrome Sandbox
+              env:
+                CHROME_SANDBOX_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}-sandbox
+              run: |
+                sudo chown root:root "$CHROME_SANDBOX_PATH"
+                sudo chmod 4755 "$CHROME_SANDBOX_PATH"
             - name: Run Integration Tests
+              env:
+                CHROME_BINARY_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
               run: npm run test:integration -- --reporters="default" --reporters="jest-junit"
             - name: Store Integration Test Results
               uses: actions/upload-artifact@v4

--- a/test/helpers/selenium-helper.js
+++ b/test/helpers/selenium-helper.js
@@ -137,7 +137,7 @@ class SeleniumHelper {
         // This is especially important on Windows, where Selenium directs JS console messages to stdout
         args.push('--autoplay-policy=no-user-gesture-required');
 
-        chromeCapabilities.set('chromeOptions', {args});
+        chromeCapabilities.set('chromeOptions', {args, binary: process.env.CHROME_BINARY_PATH});
         chromeCapabilities.setLoggingPrefs({
             performance: 'ALL'
         });


### PR DESCRIPTION
### Resolves

- Follow-up to #31

### Proposed Changes

- Use the Chromium binary installed by `browser-actions/setup-chrome` for integration tests.
- Configure that binary's Chrome sandbox before Selenium starts.

### Reason for Changes

The develop workflow installed ChromeDriver 152 but Selenium launched the runner's preinstalled Chrome 151, so every browser session failed before the test assertions ran.

### Test Coverage

- `npm run test:unit -- --runInBand --silent` (44 suites, 287 passed)
- `npx eslint . --ext .js,.jsx --ignore-pattern coverage --ignore-pattern build --ignore-pattern dist`
- [GitHub Actions integration test](https://github.com/team-monolith-product/scratch-gui/actions/runs/33853680259/job/100964524198) (passed)

### Browser Coverage

Mac
 * [ ] Chrome
 * [ ] Firefox
 * [ ] Safari

Windows
 * [ ] Chrome
 * [ ] Firefox
 * [ ] Edge

Chromebook
 * [ ] Chrome

iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
